### PR TITLE
Add stop listening method in focus picker

### DIFF
--- a/src/lib/FocusPicker.ts
+++ b/src/lib/FocusPicker.ts
@@ -37,7 +37,7 @@ export class FocusPicker {
 
   constructor(imageNode: HTMLImageElement, options: FocusPickerOptions = {}) {
     // Merge options in
-    this.options = assign(DEFAULT_OPTIONS, options)
+    this.options = assign({}, DEFAULT_OPTIONS, options)
 
     // Set up references
     this.img = imageNode
@@ -47,21 +47,11 @@ export class FocusPicker {
     this.retina.draggable = false
     this.container.appendChild(this.retina)
 
-    // Bind container events
-    this.container.addEventListener("mousedown", this.startDragging)
-    this.container.addEventListener("mousemove", this.handleMove)
-    this.container.addEventListener("mouseup", this.stopDragging)
-    this.container.addEventListener("mouseleave", this.stopDragging)
-    this.container.addEventListener("touchend", this.stopDragging)
-
-    // temporarily cast config objs until this issue is resolved
-    // https://github.com/Microsoft/TypeScript/issues/9548
-    this.container.addEventListener("touchstart", this.startDragging, { passive: true } as any)
-    this.container.addEventListener("touchmove", this.handleMove, { passive: true } as any)
-
     // Set up image
     this.img.draggable = false
-    this.img.addEventListener("load", this.updateRetinaPositionFromFocus)
+
+    // Bind events
+    this.startListening()
 
     // Assign styles
     assign(this.img.style, IMAGE_STYLES)
@@ -78,6 +68,33 @@ export class FocusPicker {
 
     // Set the focus
     this.setFocus(this.focus)
+  }
+
+  public startListening() {
+    // Bind container events
+    this.container.addEventListener("mousedown", this.startDragging)
+    this.container.addEventListener("mousemove", this.handleMove)
+    this.container.addEventListener("mouseup", this.stopDragging)
+    this.container.addEventListener("mouseleave", this.stopDragging)
+    this.container.addEventListener("touchend", this.stopDragging)
+
+    // temporarily cast config objs until this issue is resolved
+    // https://github.com/Microsoft/TypeScript/issues/9548
+    this.container.addEventListener("touchstart", this.startDragging, { passive: true } as any)
+    this.container.addEventListener("touchmove", this.handleMove, { passive: true } as any)
+
+    this.img.addEventListener("load", this.updateRetinaPositionFromFocus)
+  }
+
+  public stopListening() {
+    this.container.removeEventListener("mousedown", this.startDragging)
+    this.container.removeEventListener("mousemove", this.handleMove)
+    this.container.removeEventListener("mouseup", this.stopDragging)
+    this.container.removeEventListener("mouseleave", this.stopDragging)
+    this.container.removeEventListener("touchend", this.stopDragging)
+    this.container.removeEventListener("touchstart", this.startDragging)
+    this.container.removeEventListener("touchmove", this.handleMove)
+    this.img.removeEventListener("load", this.updateRetinaPositionFromFocus)
   }
 
   public setFocus(focus: Focus) {

--- a/src/lib/FocusedImage.test.ts
+++ b/src/lib/FocusedImage.test.ts
@@ -48,7 +48,7 @@ describe("FocusedImage", () => {
     const instance = new FocusedImage(img)
     // TODO: figure out a better way to test this private method
     const result = (instance as any).calcShift(7.064574627454072, 238.90625, 2400, 0.7133333333333334)
-    expect(result).toBe("-41.89666448659254%")
+    expect(result).toBe(-41.89666448659254)
   })
 
   it("should have element references", () => {


### PR DESCRIPTION
Also provide empty object when assigning options
so as not to mutate defaults

fixes https://github.com/third774/image-focus/issues/4