### PR TITLE
Fix contentDocument could be null

### DIFF
--- a/src/FocusedImage.ts
+++ b/src/FocusedImage.ts
@@ -75,9 +75,9 @@ export class FocusedImage {
     this.focus = this.options.focus
       ? this.options.focus
       : {
-        x: parseFloat(this.img.getAttribute('data-focus-x')) || 0,
-        y: parseFloat(this.img.getAttribute('data-focus-y')) || 0,
-      };
+          x: parseFloat(this.img.getAttribute('data-focus-x')) || 0,
+          y: parseFloat(this.img.getAttribute('data-focus-y')) || 0,
+        };
 
     // Start listening for resize events
     this.startListening();

--- a/src/FocusedImage.ts
+++ b/src/FocusedImage.ts
@@ -164,7 +164,10 @@ export class FocusedImage {
     }
     this.listening = false;
     window.removeEventListener('resize', this.debounceApplyShift);
-    if (this.resizeListenerObject && this.resizeListenerObject.contentDocument) {
+    if (
+      this.resizeListenerObject &&
+      this.resizeListenerObject.contentDocument
+    ) {
       this.resizeListenerObject.contentDocument.defaultView.removeEventListener(
         'resize',
         this.debounceApplyShift

--- a/src/FocusedImage.ts
+++ b/src/FocusedImage.ts
@@ -75,9 +75,9 @@ export class FocusedImage {
     this.focus = this.options.focus
       ? this.options.focus
       : {
-          x: parseFloat(this.img.getAttribute('data-focus-x')) || 0,
-          y: parseFloat(this.img.getAttribute('data-focus-y')) || 0,
-        };
+        x: parseFloat(this.img.getAttribute('data-focus-x')) || 0,
+        y: parseFloat(this.img.getAttribute('data-focus-y')) || 0,
+      };
 
     // Start listening for resize events
     this.startListening();
@@ -164,7 +164,7 @@ export class FocusedImage {
     }
     this.listening = false;
     window.removeEventListener('resize', this.debounceApplyShift);
-    if (this.resizeListenerObject) {
+    if (this.resizeListenerObject && this.resizeListenerObject.contentDocument) {
       this.resizeListenerObject.contentDocument.defaultView.removeEventListener(
         'resize',
         this.debounceApplyShift


### PR DESCRIPTION
We should validate both `resizeListenerObject` and `contentDocument` as they could be null and break rendering logic.