### PR TITLE
Added enable/disable feature to FocusPicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "@rollup/plugin-image": "^2.0.5",
     "husky": "^4.2.5",
     "tsdx": "^0.13.2",
-    "tslib": "^2.0.0",
-    "typescript": "^3.9.3"
-  }
+    "tslib": "^2.1.0",
+    "typescript": "^4.2.3"
+  },
+  "dependencies": {}
 }

--- a/src/FocusPicker.ts
+++ b/src/FocusPicker.ts
@@ -34,6 +34,7 @@ export class FocusPicker {
   focus: Focus;
   private isDragging: boolean;
   private options: FocusPickerOptions;
+  private _enabled: boolean = false;
 
   constructor(imageNode: HTMLImageElement, options: FocusPickerOptions = {}) {
     // Merge options in
@@ -42,32 +43,56 @@ export class FocusPicker {
     // Set up references
     this.img = imageNode;
     this.container = imageNode.parentElement;
-    this.retina = document.createElement('img');
-    this.retina.src = this.options.retina;
-    this.retina.draggable = false;
-    this.container.appendChild(this.retina);
 
-    // Set up image
+    // Styles and DOM config
     this.img.draggable = false;
-
-    // Bind events
-    this.startListening();
-
     // Assign styles
     assign(this.img.style, IMAGE_STYLES);
-    assign(this.retina.style, RETINA_STYLES);
     assign(this.container.style, CONTAINER_STYLES);
 
     // Initialize Focus coordinates
-    this.focus = this.options.focus
+    this.focus = this.getFocus();
+
+    // Create and attach the retina focal point, start listeners and attach focus
+    this.enable();
+  }
+
+  private getFocus(): Focus {
+    return this.options.focus
       ? this.options.focus
       : {
           x: parseFloat(this.img.getAttribute('data-focus-x')) || 0,
           y: parseFloat(this.img.getAttribute('data-focus-y')) || 0,
         };
+  }
 
-    // Set the focus
-    this.setFocus(this.focus);
+  /**
+   * Creates the focal point retina and
+   */
+  public enable() {
+    if (!this._enabled) {
+      // Create and attach the retina focal point
+      this.retina = document.createElement('img');
+      this.retina.src = this.options.retina;
+      this.retina.draggable = false;
+      this.container.appendChild(this.retina);
+      assign(this.retina.style, RETINA_STYLES);
+      this.startListening();
+      this.setFocus(this.focus);
+      this._enabled = true;
+    }
+  }
+
+  public disable() {
+    if (this._enabled && this.retina) {
+      this.stopListening();
+      this.container.removeChild(this.retina);
+      this._enabled = false;
+    }
+  }
+
+  get enabled(): boolean {
+    return this._enabled;
   }
 
   public startListening() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,15 @@
 {
-  "include": ["src", "types"],
+  "include": [
+    "src",
+    "types"
+  ],
   "compilerOptions": {
+    "target": "ES5",
     "module": "esnext",
-    "lib": ["dom", "esnext"],
+    "lib": [
+      "dom",
+      "esnext"
+    ],
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,
@@ -14,7 +21,10 @@
     "moduleResolution": "node",
     "baseUrl": "./",
     "paths": {
-      "*": ["src/*", "node_modules/*"]
+      "*": [
+        "src/*",
+        "node_modules/*"
+      ]
     },
     "esModuleInterop": true
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1676,9 +1676,9 @@ camelcase@^5.0.0, camelcase@^5.2.0, camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001043:
-  version "1.0.30001062"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001062.tgz#d814b648338504b315222ace6f1a533d9a55e390"
-  integrity sha512-ei9ZqeOnN7edDrb24QfJ0OZicpEbsWxv7WusOiQGz/f2SfvBgHHbOEwBJ8HKGVSyx8Z6ndPjxzR6m0NQq+0bfw==
+  version "1.0.30001197"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001197.tgz"
+  integrity sha512-8aE+sqBqtXz4G8g35Eg/XEaFr2N7rd/VQ6eABGBmNtcB8cN6qNJhMi6oSFy4UWWZgqgL3filHT8Nha4meu3tsw==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -5631,10 +5631,10 @@ tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
-tslib@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
-  integrity sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
+tslib@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
 tsutils@^3.17.1:
   version "3.17.1"
@@ -5672,10 +5672,15 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@^3.7.3, typescript@^3.9.3:
+typescript@^3.7.3:
   version "3.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
   integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==
+
+typescript@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
+  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
- Added public enable/disable options that remove the retina and listeners
- added private enabled boolean to see if a FocusPicker is enabled or not
- updated TS and tslib

This feature allows for easy integration into React because it allows the
retina to be taken off the DOM when the image isn't in view (or rendering null).

Also went with enable/disable as it works for temporary or permenant use.